### PR TITLE
[bot] Add /autopilot and /goal commands to agents category (v1.0.55)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Built with React, Vite, and TypeScript. Data-driven — all commands are split i
 
 ## Categories
 
-The 65 commands are organized into 11 categories:
+The 66 commands are organized into 11 categories:
 
 | Category           | Commands | Description                                             |
 | ------------------ | -------- | ------------------------------------------------------- |
@@ -29,7 +29,7 @@ The 65 commands are organized into 11 categories:
 | 🧬 Models          | 3        | Model selection, experimental features, themes          |
 | ⚙️ Configuration   | 13       | Directories, permissions, environment, voice, streaming |
 | 💻 Code            | 5        | Diff, plan, PR management, code review, security review |
-| 🤖 Agents          | 8        | Agent picker, fleet, delegate, research, tasks          |
+| 🤖 Agents          | 9        | Agent picker, fleet, delegate, research, tasks          |
 | 🔌 MCP             | 2        | MCP and LSP server management                           |
 | 🧠 Memory          | 6        | Sessions, context, compaction, sharing                  |
 | 📝 Instructions    | 3        | Custom instructions, skills, plugins                    |

--- a/scripts/demos.json
+++ b/scripts/demos.json
@@ -577,6 +577,13 @@
     },
 
     {
+      "id": "autopilot",
+      "category": "agents",
+      "description": "Set a focused autopilot objective for the session",
+      "command": "/autopilot fix all TypeScript errors in src/",
+      "responseWait": 20
+    },
+    {
       "id": "exit",
       "category": "troubleshooting",
       "description": "Exit the session cleanly",

--- a/src/data/categories/agents.json
+++ b/src/data/categories/agents.json
@@ -93,6 +93,19 @@
     "terminalDemo": "images/agents/sidekicks.gif"
   },
   {
+    "id": "autopilot",
+    "title": "/autopilot",
+    "syntax": "/autopilot <OBJECTIVE>",
+    "description": "Lock the agent onto a specific objective for the session. Copilot stays focused on that goal until it is complete or you change it. Use /goal as an alias.",
+    "analogy": "Like setting a GPS destination — Copilot navigates toward the goal and ignores distractions until it arrives.",
+    "examples": [
+      "/autopilot migrate all API calls to use fetch instead of axios",
+      "/autopilot add TypeScript strict mode and fix all resulting errors",
+      "/goal refactor the auth module to use JWTs  # /goal is an alias for /autopilot"
+    ],
+    "category": "agents"
+  },
+  {
     "id": "tasks",
     "title": "/tasks",
     "syntax": "/tasks",


### PR DESCRIPTION
> [!CAUTION]
> Protected files were modified in this change.
> This pull request is in `request_review` mode and requires explicit human scrutiny before merge.
>
> Protected files: `README.md`



## What changed

Added two new commands introduced in [v1.0.55](https://github.com/github/copilot-cli/releases/tag/v1.0.55) (released 2026-05-28):

- **`/autopilot <OBJECTIVE>`** — locks the session onto a specific goal; Copilot stays focused until the task is complete or the objective changes
- **`/goal`** — alias for `/autopilot`

These were announced in the v1.0.55 stable release changelog entry:
> Add `/autopilot <objective>` to keep autopilot focused, with `/goal` as an alias

## Files updated

| File | Change |
|---|---|
| `src/data/categories/agents.json` | Added `/autopilot` command entry (includes `/goal` alias in examples) |
| `scripts/demos.json` | Added `autopilot` demo entry with `responseWait: 20` |
| `README.md` | Updated Agents count 8 → 9, total 65 → 66 |

## Pending availability

No commands are pending — all changes in this PR are confirmed in the v1.0.55 stable release.

The following items from v1.0.56–v1.0.57 prerelease notes were **excluded** (settings/UX improvements, not new slash commands):
- `builtInAgents.rubberDuck` config setting (v1.0.56) — config-only, no new slash command
- `showTipsOnStartup` setting (v1.0.57-1) — prerelease, config-only

---

> ⚠️ **Needs GIFs**: A demo tape entry was added for `/autopilot`. Record locally after merge:
> ```bash
> npm run create:tape
> npm run create:gif -- --category agents
> ```




> Generated by [Cheatsheet Updater](https://github.com/prasadhonrao/ghcp-cli-cheatsheet/actions/runs/26748298076) · sonnet46 1.4M · [◷](https://github.com/search?q=repo%3Aprasadhonrao%2Fghcp-cli-cheatsheet+%22gh-aw-workflow-id%3A+cheatsheet-updater%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Cheatsheet Updater, engine: copilot, version: 1.0.52, model: claude-sonnet-4.6, id: 26748298076, workflow_id: cheatsheet-updater, run: https://github.com/prasadhonrao/ghcp-cli-cheatsheet/actions/runs/26748298076 -->

<!-- gh-aw-workflow-id: cheatsheet-updater -->