### PR TITLE
[bot] Add /app, /settings, /worktree, /every, /after — commands from v1.0.58–1.0.63

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,16 +19,16 @@ Built with React, Vite, and TypeScript. Data-driven — all commands are split i
 
 ## Categories
 
-The 65 commands are organized into 11 categories:
+The 67 commands are organized into 11 categories:
 
 | Category           | Commands | Description                                             |
 | ------------------ | -------- | ------------------------------------------------------- |
-| 🚀 Getting Started | 8        | Install, update, help, version, feedback                |
+| 🚀 Getting Started | 9        | Install, update, help, version, feedback                |
 | 🔐 Authentication  | 3        | Login, logout, account switching                        |
-| 💬 Chat            | 5        | Ask, clear, search, undo, new                           |
+| 💬 Chat            | 6        | Ask, clear, copy, search, undo, new                     |
 | 🧬 Models          | 3        | Model selection, experimental features, themes          |
-| ⚙️ Configuration   | 13       | Directories, permissions, environment, voice, streaming |
-| 💻 Code            | 5        | Diff, plan, PR management, code review, security review |
+| ⚙️ Configuration   | 15       | Directories, permissions, environment, scheduling, settings |
+| 💻 Code            | 6        | Diff, plan, PR management, code review, worktree        |
 | 🤖 Agents          | 8        | Agent picker, fleet, delegate, research, tasks          |
 | 🔌 MCP             | 2        | MCP and LSP server management                           |
 | 🧠 Memory          | 6        | Sessions, context, compaction, sharing                  |

--- a/scripts/demos.json
+++ b/scripts/demos.json
@@ -235,6 +235,13 @@
       ]
     },
     {
+      "id": "worktree",
+      "category": "code",
+      "description": "Create a git worktree for a branch",
+      "command": "/worktree feature/my-branch",
+      "responseWait": 10
+    },
+    {
       "id": "diff",
       "category": "code",
       "description": "Review and explain git diff",
@@ -274,6 +281,13 @@
       "description": "Run code review agent",
       "command": "/review",
       "responseWait": 20
+    },
+    {
+      "id": "after",
+      "category": "configuration",
+      "description": "Schedule a one-time task after a delay",
+      "command": "/after 30m remind me to commit and push my changes",
+      "responseWait": 6
     },
     {
       "id": "add-dir",
@@ -348,6 +362,20 @@
       "responseWait": 6
     },
     {
+      "id": "every",
+      "category": "configuration",
+      "description": "Schedule a recurring task on an interval",
+      "command": "/every 1d /chronicle standup",
+      "responseWait": 6
+    },
+    {
+      "id": "settings",
+      "category": "configuration",
+      "description": "Open interactive settings browser",
+      "command": "/settings",
+      "responseWait": 6
+    },
+    {
       "id": "statusline",
       "category": "configuration",
       "description": "Configure status line items",
@@ -373,6 +401,13 @@
       "category": "configuration",
       "description": "Enable voice input",
       "command": "/voice on",
+      "responseWait": 6
+    },
+    {
+      "id": "app",
+      "category": "getting-started",
+      "description": "Open the GitHub app or browser",
+      "command": "/app",
       "responseWait": 6
     },
     {

--- a/src/data/categories/chat.json
+++ b/src/data/categories/chat.json
@@ -69,11 +69,11 @@
     "id": "undo",
     "title": "/undo",
     "syntax": "/undo",
-    "description": "Rewind the last turn and revert any file changes Copilot made. Also available as /rewind.",
+    "description": "Rewind the last turn and revert any file changes Copilot made. Also available as /rewind. In experimental mode, /rewind has enhanced behavior: it no longer requires git and lets you choose between reverting just the conversation or both the conversation and files.",
     "analogy": "Like Ctrl+Z for a Copilot action — undo the last step if the result was not what you wanted.",
     "examples": [
       "/undo  # revert the last turn and its file changes",
-      "/rewind  # alias for /undo"
+      "/rewind  # in experimental mode, offers conversation-only or full revert"
     ],
     "category": "chat",
     "terminalDemo": "images/chat/undo.gif"

--- a/src/data/categories/code.json
+++ b/src/data/categories/code.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "worktree",
+    "title": "/worktree",
+    "syntax": "/worktree [BRANCH]",
+    "description": "Create a new git worktree and switch into it, carrying any uncommitted changes along. Also available as /move.",
+    "analogy": "Like opening a parallel workspace for your project — work on two branches simultaneously without stashing or committing half-done work.",
+    "examples": [
+      "/worktree feature/my-branch  # create a worktree for an existing or new branch",
+      "/move  # alias for /worktree"
+    ],
+    "category": "code"
+  },
+  {
     "id": "diff",
     "title": "/diff",
     "syntax": "/diff",

--- a/src/data/categories/configuration.json
+++ b/src/data/categories/configuration.json
@@ -1,5 +1,18 @@
 [
   {
+    "id": "after",
+    "title": "/after",
+    "syntax": "/after <DURATION|TIME> <PROMPT|SLASH-COMMAND>",
+    "description": "Schedule a prompt or slash command to run once after a delay or at a specific calendar time. Accepts natural language durations (30m, 2h) and times. Only available in experimental mode.",
+    "analogy": "Like setting a one-time reminder on your phone — Copilot picks up a task for you after you step away.",
+    "examples": [
+      "/after 30m remind me to commit and push my changes",
+      "/after 2h /chronicle standup  # run standup 2 hours from now"
+    ],
+    "note": "Requires /experimental mode. See also: /every — for recurring schedules.",
+    "category": "configuration"
+  },
+  {
     "id": "add-dir",
     "title": "/add-dir",
     "syntax": "/add-dir <PATH>",
@@ -108,6 +121,30 @@
     ],
     "category": "configuration",
     "terminalDemo": "images/configuration/reset-allowed-tools.gif"
+  },
+  {
+    "id": "every",
+    "title": "/every",
+    "syntax": "/every <DURATION|CRON> <PROMPT|SLASH-COMMAND>",
+    "description": "Schedule a prompt or slash command to run repeatedly on a given interval or cron expression. Supports natural language durations like 1h, 30m, or 1d. Only available in experimental mode.",
+    "analogy": "Like setting a recurring alarm for a task — Copilot runs it automatically at the interval you choose, even when you step away.",
+    "examples": [
+      "/every 1h check for new GitHub issues and summarize them",
+      "/every 1d /chronicle standup  # daily standup report"
+    ],
+    "note": "Requires /experimental mode. See also: /after — for one-time scheduled tasks.",
+    "category": "configuration"
+  },
+  {
+    "id": "settings",
+    "title": "/settings",
+    "syntax": "/settings",
+    "description": "Open an interactive dialog to browse and edit all user settings in one place without editing config files manually.",
+    "analogy": "Like opening the Preferences panel in an app — browse every configurable option and change it interactively.",
+    "examples": [
+      "/settings  # open the interactive settings browser"
+    ],
+    "category": "configuration"
   },
   {
     "id": "statusline",

--- a/src/data/categories/getting-started.json
+++ b/src/data/categories/getting-started.json
@@ -1,5 +1,16 @@
 [
   {
+    "id": "app",
+    "title": "/app",
+    "syntax": "/app",
+    "description": "Open the GitHub app or a browser fallback. Quickly access the GitHub web interface from within an active session.",
+    "analogy": "Like a home button that takes you straight to GitHub — one command to open the app without leaving your terminal workflow.",
+    "examples": [
+      "/app  # open the GitHub app or browser"
+    ],
+    "category": "getting-started"
+  },
+  {
     "id": "bug",
     "title": "/bug",
     "syntax": "/bug",


### PR DESCRIPTION
Closing as superseded. All commands (/app, /settings, /worktree) were merged via PR #18, and /every + /after via PR #15. The only net-new change (updated /undo description for enhanced /rewind experimental behavior) was applied directly to main.