### PR TITLE
[bot] Add /diagnose, /fork, /branch, /loop from v1.0.64–1.0.65

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,21 +19,21 @@ Built with React, Vite, and TypeScript. Data-driven — all commands are split i
 
 ## Categories
 
-The 65 commands are organized into 11 categories:
+The 66 commands are organized into 11 categories:
 
 | Category           | Commands | Description                                             |
 | ------------------ | -------- | ------------------------------------------------------- |
 | 🚀 Getting Started | 8        | Install, update, help, version, feedback                |
 | 🔐 Authentication  | 3        | Login, logout, account switching                        |
-| 💬 Chat            | 5        | Ask, clear, search, undo, new                           |
+| 💬 Chat            | 6        | Ask, clear, copy, search, undo, new                     |
 | 🧬 Models          | 3        | Model selection, experimental features, themes          |
 | ⚙️ Configuration   | 13       | Directories, permissions, environment, voice, streaming |
-| 💻 Code            | 5        | Diff, plan, PR management, code review, security review |
+| 💻 Code            | 7        | Diff, plan, PR management, code review, fork, branch    |
 | 🤖 Agents          | 8        | Agent picker, fleet, delegate, research, tasks          |
 | 🔌 MCP             | 2        | MCP and LSP server management                           |
 | 🧠 Memory          | 6        | Sessions, context, compaction, sharing                  |
 | 📝 Instructions    | 3        | Custom instructions, skills, plugins                    |
-| 🔧 Troubleshooting | 6        | Diagnostics, restart, remote control, exit              |
+| 🔧 Troubleshooting | 7        | Diagnostics, restart, remote control, exit, diagnose    |
 
 ## Tech stack
 

--- a/scripts/demos.json
+++ b/scripts/demos.json
@@ -235,6 +235,13 @@
       ]
     },
     {
+      "id": "branch",
+      "category": "code",
+      "description": "Create a GitHub fork of the current repository",
+      "command": "/branch",
+      "responseWait": 10
+    },
+    {
       "id": "diff",
       "category": "code",
       "description": "Review and explain git diff",
@@ -246,6 +253,13 @@
         { "key": "Escape" },
         { "wait": 2 }
       ]
+    },
+    {
+      "id": "fork",
+      "category": "code",
+      "description": "Create a GitHub fork of the current repository",
+      "command": "/fork",
+      "responseWait": 10
     },
     {
       "id": "plan",
@@ -338,6 +352,13 @@
       "category": "configuration",
       "description": "List allowed directories",
       "command": "/list-dirs",
+      "responseWait": 6
+    },
+    {
+      "id": "loop",
+      "category": "configuration",
+      "description": "Schedule a recurring prompt",
+      "command": "/loop 1h /usage",
       "responseWait": 6
     },
     {
@@ -558,6 +579,13 @@
       "category": "troubleshooting",
       "description": "Collect debug logs",
       "command": "/collect-debug-logs",
+      "responseWait": 10
+    },
+    {
+      "id": "diagnose",
+      "category": "troubleshooting",
+      "description": "Analyze session logs for errors and anomalies",
+      "command": "/diagnose",
       "responseWait": 10
     },
     {

--- a/src/data/categories/code.json
+++ b/src/data/categories/code.json
@@ -1,5 +1,18 @@
 [
   {
+    "id": "branch",
+    "title": "/branch",
+    "syntax": "/branch",
+    "description": "Create a GitHub fork of the current repository. Alias for /fork, matching Claude Code command naming.",
+    "analogy": "Like clicking 'Fork' in the GitHub UI — creates your personal copy of the repo so you can make changes without affecting the original.",
+    "examples": [
+      "/branch  # create a GitHub fork of the current repository",
+      "/fork  # alias for /branch"
+    ],
+    "category": "code",
+    "note": "See also: /fork — a co-equal alias for the same command."
+  },
+  {
     "id": "diff",
     "title": "/diff",
     "syntax": "/diff",
@@ -10,6 +23,19 @@
     ],
     "category": "code",
     "terminalDemo": "images/code/diff.gif"
+  },
+  {
+    "id": "fork",
+    "title": "/fork",
+    "syntax": "/fork",
+    "description": "Create a GitHub fork of the current repository. Copilot shows a progress notification while the fork is being created.",
+    "analogy": "Like clicking 'Fork' in the GitHub UI — creates your personal copy of the repo so you can make changes without affecting the original.",
+    "examples": [
+      "/fork  # create a GitHub fork of the current repository",
+      "/branch  # alias for /fork"
+    ],
+    "category": "code",
+    "note": "See also: /branch — a co-equal alias added in v1.0.64."
   },
   {
     "id": "plan",

--- a/src/data/categories/configuration.json
+++ b/src/data/categories/configuration.json
@@ -98,6 +98,20 @@
     "terminalDemo": "images/configuration/list-dirs.gif"
   },
   {
+    "id": "loop",
+    "title": "/loop",
+    "syntax": "/loop <DURATION|CRON> <PROMPT|SLASH-COMMAND>",
+    "description": "Schedule a prompt or slash command to run repeatedly on a given interval or cron expression. Alias for /every. Only available in experimental mode.",
+    "analogy": "Like a recurring calendar event for AI tasks — set it and Copilot runs the prompt automatically on your chosen schedule.",
+    "examples": [
+      "/loop 1h check for new GitHub issues and summarize them",
+      "/loop 1d /chronicle standup  # daily standup report",
+      "/every  # alias for /loop"
+    ],
+    "note": "Requires /experimental mode. See also: /every — a co-equal alias for the same command.",
+    "category": "configuration"
+  },
+  {
     "id": "reset-allowed-tools",
     "title": "/reset-allowed-tools",
     "syntax": "/reset-allowed-tools",

--- a/src/data/categories/instructions.json
+++ b/src/data/categories/instructions.json
@@ -30,14 +30,16 @@
     "id": "skills",
     "title": "/skills",
     "syntax": "/skills [list|info|add|remove|reload] [ARGS...]",
-    "description": "Manage custom skills — Markdown files that extend Copilot's capabilities. Skills live in .github/skills/, ~/.copilot/skills/, or plugin directories.",
+    "description": "Manage custom skills — Markdown files that extend Copilot's capabilities. Skills live in .github/skills/, ~/.copilot/skills/, or plugin directories. Also available as /skill.",
     "analogy": "Like a library of custom macros in your editor — each skill adds a reusable capability you can invoke by name.",
     "examples": [
       "/skills list  # show all loaded skills and their sources",
       "/skills info my-skill  # show details about a specific skill",
-      "/skills reload  # reload skills after adding or editing files"
+      "/skills reload  # reload skills after adding or editing files",
+      "/skill list  # alias for /skills list"
     ],
     "category": "instructions",
+    "note": "See also: /skill — a co-equal alias added in v1.0.65.",
     "terminalDemo": "images/instructions/skills.gif"
   }
 ]

--- a/src/data/categories/mcp.json
+++ b/src/data/categories/mcp.json
@@ -16,14 +16,15 @@
   {
     "id": "mcp",
     "title": "/mcp",
-    "syntax": "/mcp [show|add|edit|delete|disable|enable|auth|reload] [SERVER]",
-    "description": "Manage MCP (Model Context Protocol) server configurations — add, remove, enable, disable, or reload servers from within a session.",
+    "syntax": "/mcp [show|add|edit|delete|disable|enable|auth|reload|registry] [SERVER]",
+    "description": "Manage MCP (Model Context Protocol) server configurations — add, remove, enable, disable, reload servers, or browse the MCP registry to install new servers.",
     "analogy": "Like a plugin manager in an IDE — /mcp is the control panel for every external tool extension connected to Copilot.",
     "examples": [
       "/mcp show  # list all configured MCP servers and their status",
       "/mcp disable my-server  # temporarily disable a server without removing it",
       "/mcp reload  # reload all MCP server configs without restarting",
-      "/mcp auth my-server  # trigger a fresh OAuth flow for a remote server"
+      "/mcp auth my-server  # trigger a fresh OAuth flow for a remote server",
+      "/mcp registry  # browse and install MCP servers from the registry"
     ],
     "category": "mcp",
     "terminalDemo": "images/mcp/mcp.gif"

--- a/src/data/categories/troubleshooting.json
+++ b/src/data/categories/troubleshooting.json
@@ -13,6 +13,17 @@
     "terminalDemo": "images/troubleshooting/collect-debug-logs.gif"
   },
   {
+    "id": "diagnose",
+    "title": "/diagnose",
+    "syntax": "/diagnose",
+    "description": "Analyze session logs to help identify errors, unexpected behavior, or performance issues from the current session.",
+    "analogy": "Like opening a black-box recorder after an incident — surfaces what the CLI actually did so you can pinpoint what went wrong.",
+    "examples": [
+      "/diagnose  # analyze session logs for errors and anomalies"
+    ],
+    "category": "troubleshooting"
+  },
+  {
     "id": "diagnosis",
     "title": "/diagnosis",
     "syntax": "/diagnosis",
@@ -25,7 +36,6 @@
     "category": "troubleshooting",
     "terminalDemo": "images/troubleshooting/diagnosis.gif"
   },
-
   {
     "id": "exit",
     "title": "/exit",


### PR DESCRIPTION
> [!CAUTION]
> Protected files were modified in this change.
> This pull request is in `request_review` mode and requires explicit human scrutiny before merge.
>
> Protected files: `README.md`



## What changed

This PR documents new commands and updates from **Copilot CLI v1.0.64** (stable, 2026-06-23) and **v1.0.65** (stable, 2026-06-24). [Changelog](https://github.com/github/copilot-cli/blob/main/changelog.md)

---

## Files updated

### `src/data/categories/troubleshooting.json`
- **Added `/diagnose`** — new command to analyze session logs for errors, unexpected behavior, or performance issues. Different from the existing `/diagnosis` (which checks environment connectivity and auth); `/diagnose` inspects the session log itself.

### `src/data/categories/code.json`
- **Added `/fork`** — create a GitHub fork of the current repository. Copilot shows a progress notification while the fork is being created.
- **Added `/branch`** — alias for `/fork`, matching Claude Code command naming (v1.0.64).

### `src/data/categories/configuration.json`
- **Added `/loop`** — alias for `/every`; schedules a prompt or slash command to run repeatedly on a given interval or cron expression. Requires experimental mode. (Note: `/every` itself is documented in an open PR `update/add-app-settings-worktree-every-after-4424988f0178b63b`.)

### `src/data/categories/mcp.json`
- **Updated `/mcp`** syntax to include the new `registry` subcommand (`/mcp registry`) for browsing and installing MCP servers from the registry.

### `src/data/categories/instructions.json`
- **Updated `/skills`** to document `/skill` as a co-equal alias (added in v1.0.65).

### `scripts/demos.json`
- Added demo entries for: `/diagnose`, `/fork`, `/branch`, `/loop`.

### `README.md`
- Updated total command count: **65 → 66**
- Code category: 5 → 7 (adds /fork and /branch)
- Troubleshooting category: 6 → 7 (adds /diagnose)
- Chat category: corrected 5 → 6 (was already 6 in the JSON, README had a pre-existing off-by-one)

---

## Commands confirmed in stable releases

| Command | Release | Status |
|---------|---------|--------|
| `/diagnose` | v1.0.64 (2026-06-23) | ✅ Available |
| `/fork` | pre-v1.0.64 | ✅ Available |
| `/branch` | v1.0.64 (2026-06-23) | ✅ Available |
| `/loop` | v1.0.64 (2026-06-23) | ✅ Available |
| `/mcp registry` | v1.0.64 (2026-06-23) | ✅ Available |
| `/skill` alias | v1.0.65 (2026-06-24) | ✅ Available |

---

## Already covered by open PRs (excluded)

- `/every`, `/after`, `/settings`, `/app`, `/worktree` — covered by `update/add-app-settings-worktree-every-after-4424988f0178b63b`
- `/autopilot`, `/goal` — covered by `cheatsheet-update-autopilot-v1.0.55-71d784d31b179738`

---

## Pending availability

The following changes from **prerelease** builds (v1.0.66-0 and v1.0.66-1, both `prerelease: true`) are **excluded** from this PR until they ship in a stable release:

- `/chronicle skills review` — review proposed draft skill changes (v1.0.66-1 prerelease)
- `/share` using Mission Control links (v1.0.66-1 prerelease)
- `/worktree <task>` — pass a task to name the branch (v1.0.66-0 prerelease)
- Configure subagent concurrency/depth in `/settings` (v1.0.66-1 prerelease)

---

> 🎬 **Note for maintainer**: New commands need GIF recordings. Run after merge:
> ```bash
> npm run create:tape
> npm run create:gif -- --category troubleshooting
> npm run create:gif -- --category code
> npm run create:gif -- --category configuration
> ```




> Generated by [Cheatsheet Updater](https://github.com/prasadhonrao/ghcp-cli-cheatsheet/actions/runs/28361586652) · sonnet46 5.6M · [◷](https://github.com/search?q=repo%3Aprasadhonrao%2Fghcp-cli-cheatsheet+%22gh-aw-workflow-id%3A+cheatsheet-updater%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Cheatsheet Updater, engine: copilot, version: 1.0.52, model: claude-sonnet-4.6, id: 28361586652, workflow_id: cheatsheet-updater, run: https://github.com/prasadhonrao/ghcp-cli-cheatsheet/actions/runs/28361586652 -->

<!-- gh-aw-workflow-id: cheatsheet-updater -->