### PR TITLE
[bot] Add /worktree, /chronicle skills review, /lsp logs, and /pr automerge from v1.0.66–v1.0.68

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Built with React, Vite, and TypeScript. Data-driven — all commands are split i
 
 ## Categories
 
-The 65 commands are organized into 11 categories:
+The 66 commands are organized into 11 categories:
 
 | Category           | Commands | Description                                             |
 | ------------------ | -------- | ------------------------------------------------------- |
@@ -28,7 +28,7 @@ The 65 commands are organized into 11 categories:
 | 💬 Chat            | 5        | Ask, clear, search, undo, new                           |
 | 🧬 Models          | 3        | Model selection, experimental features, themes          |
 | ⚙️ Configuration   | 13       | Directories, permissions, environment, voice, streaming |
-| 💻 Code            | 5        | Diff, plan, PR management, code review, security review |
+| 💻 Code            | 6        | Diff, plan, PR management, code review, security review, worktree |
 | 🤖 Agents          | 8        | Agent picker, fleet, delegate, research, tasks          |
 | 🔌 MCP             | 2        | MCP and LSP server management                           |
 | 🧠 Memory          | 6        | Sessions, context, compaction, sharing                  |

--- a/scripts/demos.json
+++ b/scripts/demos.json
@@ -269,6 +269,13 @@
       "responseWait": 20
     },
     {
+      "id": "worktree",
+      "category": "code",
+      "description": "Create a git worktree with a task-named branch",
+      "command": "/worktree fix the login redirect",
+      "responseWait": 10
+    },
+    {
       "id": "review",
       "category": "code",
       "description": "Run code review agent",

--- a/src/data/categories/agents.json
+++ b/src/data/categories/agents.json
@@ -14,15 +14,16 @@
   {
     "id": "chronicle",
     "title": "/chronicle",
-    "syntax": "/chronicle <standup|tips|improve|reindex|search|cost-tips>",
-    "description": "Session history tools and insights. Subcommands: standup (generate a standup report), tips (get workflow tips), improve (suggestions to work more effectively), reindex (rebuild the history index), search (search all session content by keyword or topic), cost-tips (personalized token usage and cost reduction recommendations). Only available in experimental mode.",
+    "syntax": "/chronicle <standup|tips|improve|reindex|search|cost-tips|skills>",
+    "description": "Session history tools and insights. Subcommands: standup (generate a standup report), tips (get workflow tips), improve (suggestions to work more effectively), reindex (rebuild the history index), search (search all session content by keyword or topic), cost-tips (personalized token usage and cost reduction recommendations), skills (manage draft skill changes). Only available in experimental mode.",
     "analogy": "Like a smart journal for your coding sessions — chronicle turns your work history into actionable summaries and advice.",
     "examples": [
       "/chronicle standup  # generate a standup report from recent sessions",
       "/chronicle tips  # get workflow tips based on your usage patterns",
       "/chronicle improve  # suggestions to work more effectively with Copilot",
       "/chronicle search JWT  # search all sessions for mentions of JWT",
-      "/chronicle cost-tips  # get personalized tips to reduce token usage"
+      "/chronicle cost-tips  # get personalized tips to reduce token usage",
+      "/chronicle skills review  # review proposed draft skill changes (accept, reject, or defer)"
     ],
     "category": "agents",
     "terminalDemo": "images/agents/chronicle.gif"

--- a/src/data/categories/code.json
+++ b/src/data/categories/code.json
@@ -27,14 +27,15 @@
   {
     "id": "pr",
     "title": "/pr",
-    "syntax": "/pr [view|create|fix|auto]",
-    "description": "Manage pull requests for the current branch: view existing PRs, create one with an AI-generated description, auto-fix review comments, or use auto mode.",
+    "syntax": "/pr [view|create|fix|auto|automerge]",
+    "description": "Manage pull requests for the current branch: view existing PRs, create one with an AI-generated description, auto-fix review comments, run a self-paced loop to drive the PR to green, or keep looping until the PR is merged.",
     "analogy": "Like a PR dashboard inside your terminal — create, inspect, and respond to review feedback without switching context.",
     "examples": [
       "/pr view  # show the open PR for the current branch",
       "/pr create  # create a PR with an AI-generated description",
       "/pr fix  # let Copilot automatically address review comments",
-      "/pr auto  # create PR and fix review comments automatically"
+      "/pr auto  # self-paced loop: fix one thing per run, pace around CI to reach green",
+      "/pr automerge  # keep looping until the PR passes CI and is merged"
     ],
     "category": "code",
     "terminalDemo": "images/code/pr.gif"
@@ -61,6 +62,19 @@
     "examples": [
       "/security-review  # scan current diff for security vulnerabilities",
       "/security-review focus on injection and auth issues"
+    ],
+    "category": "code"
+  },
+  {
+    "id": "worktree",
+    "title": "/worktree",
+    "syntax": "/worktree [TASK]",
+    "description": "Create a new git worktree for parallel development. Pass an optional task description to auto-name the branch and run the task as the first prompt in the new worktree. Without an argument, names the branch from your uncommitted changes and recent conversation.",
+    "analogy": "Like opening a parallel universe of your repo — work on a separate branch simultaneously without disturbing your current session.",
+    "examples": [
+      "/worktree  # create a worktree with a branch named from current changes",
+      "/worktree fix the login redirect  # create branch for this task and start it immediately",
+      "/worktree feature/JIRA-123  # create worktree with an exact branch name"
     ],
     "category": "code"
   }

--- a/src/data/categories/mcp.json
+++ b/src/data/categories/mcp.json
@@ -2,13 +2,14 @@
   {
     "id": "lsp",
     "title": "/lsp",
-    "syntax": "/lsp [show|test|reload|help] [SERVER-NAME]",
+    "syntax": "/lsp [show|test|reload|logs|help] [SERVER-NAME]",
     "description": "Manage language server (LSP) configurations that give Copilot live diagnostics, type information, and symbol references from your codebase.",
     "analogy": "Like plugging a code-aware lens into Copilot — the LSP feeds it real-time type errors and definitions from your actual project.",
     "examples": [
       "/lsp show  # list all configured language servers",
       "/lsp test typescript  # test the TypeScript language server connection",
-      "/lsp reload  # reload LSP configs after making changes"
+      "/lsp reload  # reload LSP configs after making changes",
+      "/lsp logs  # view LSP server log output for debugging"
     ],
     "category": "mcp",
     "terminalDemo": "images/mcp/lsp.gif"


### PR DESCRIPTION
> [!CAUTION]
> Protected files were modified in this change.
> This pull request is in `request_review` mode and requires explicit human scrutiny before merge.
>
> Protected files: `README.md`



## What changed

Based on GitHub Copilot CLI releases [v1.0.66](https://github.com/github/copilot-cli/releases/tag/v1.0.66) (stable, 2026-06-30), [v1.0.67](https://github.com/github/copilot-cli/releases/tag/v1.0.67) (stable, 2026-06-30), and [v1.0.68](https://github.com/github/copilot-cli/releases/tag/v1.0.68) (stable, 2026-07-01).

### New command

**`/worktree`** (`code` category) — Create a new git worktree for parallel development. Pass an optional task description to auto-name the branch and run the task as the first prompt in the new worktree. Without an argument, names the branch from uncommitted changes and recent conversation.

> v1.0.66: _"Pass a task to /worktree (e.g. 'fix the login redirect') to name the branch for that task and run the sentence as the first prompt in the new worktree"_ / _"/worktree keeps a valid branch name exactly as typed, e.g. feature/JIRA-123"_

### Updated commands

| Command | Change | Release |
|---|---|---|
| `/chronicle` | Added `skills` subcommand; new example `/chronicle skills review` to review proposed draft skill changes | v1.0.66 |
| `/lsp` | Added `logs` subcommand (`/lsp logs`) to view LSP server log output | v1.0.66 |
| `/pr` | Added `automerge` subcommand; updated `/pr auto` description to reflect new self-paced loop behaviour | v1.0.66 |

### Files changed

- `src/data/categories/code.json` — Added `/worktree` entry; updated `/pr` syntax, description, and examples
- `src/data/categories/agents.json` — Updated `/chronicle` syntax and examples to include `skills`
- `src/data/categories/mcp.json` — Updated `/lsp` syntax and examples to include `logs`
- `scripts/demos.json` — Added `/worktree` demo entry
- `README.md` — Updated total command count (65 → 66) and Code category count (5 → 6)

## Pending availability

The following changelog items were excluded because they appear only in prerelease builds and have not yet shipped in a stable release:

- **`/mcp list`** — Added in [v1.0.69-1](https://github.com/github/copilot-cli/releases/tag/v1.0.69-1) (prerelease, 2026-07-04). Shows attached MCP servers and their status; also allows `/mcp list` and `/plugin list` to run while the agent is working. Will be added once a stable release ships.

---

> ⚠️ **needs-gifs**: The new `/worktree` command needs a GIF demo recorded locally after merge:
> ```bash
> npm run create:tape
> npm run create:gif -- --category code
> ```




> Generated by [Cheatsheet Updater](https://github.com/prasadhonrao/ghcp-cli-cheatsheet/actions/runs/28779324958) · sonnet46 2.7M · [◷](https://github.com/search?q=repo%3Aprasadhonrao%2Fghcp-cli-cheatsheet+%22gh-aw-workflow-id%3A+cheatsheet-updater%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Cheatsheet Updater, engine: copilot, version: 1.0.52, model: claude-sonnet-4.6, id: 28779324958, workflow_id: cheatsheet-updater, run: https://github.com/prasadhonrao/ghcp-cli-cheatsheet/actions/runs/28779324958 -->

<!-- gh-aw-workflow-id: cheatsheet-updater -->