### PR TITLE
[bot] Add /worktree, /chronicle skills review, /lsp logs, and /pr automerge from v1.0.66–v1.0.68

### DIFF
--- a/scripts/demos.json
+++ b/scripts/demos.json
@@ -297,6 +297,13 @@
       "responseWait": 20
     },
     {
+      "id": "worktree",
+      "category": "code",
+      "description": "Create a git worktree with a task-named branch",
+      "command": "/worktree fix the login redirect",
+      "responseWait": 10
+    },
+    {
       "id": "review",
       "category": "code",
       "description": "Run code review agent",

--- a/src/data/categories/agents.json
+++ b/src/data/categories/agents.json
@@ -17,15 +17,16 @@
   {
     "id": "chronicle",
     "title": "/chronicle",
-    "syntax": "/chronicle <standup|tips|improve|reindex|search|cost-tips>",
-    "description": "Session history tools and insights. Subcommands: standup (generate a standup report), tips (get workflow tips), improve (suggestions to work more effectively), reindex (rebuild the history index), search (search all session content by keyword or topic), cost-tips (personalized token usage and cost reduction recommendations). Only available in experimental mode.",
+    "syntax": "/chronicle <standup|tips|improve|reindex|search|cost-tips|skills>",
+    "description": "Session history tools and insights. Subcommands: standup (generate a standup report), tips (get workflow tips), improve (suggestions to work more effectively), reindex (rebuild the history index), search (search all session content by keyword or topic), cost-tips (personalized token usage and cost reduction recommendations), skills (manage draft skill changes). Only available in experimental mode.",
     "analogy": "Like a smart journal for your coding sessions — chronicle turns your work history into actionable summaries and advice.",
     "examples": [
       "/chronicle standup  # generate a standup report from recent sessions",
       "/chronicle tips  # get workflow tips based on your usage patterns",
       "/chronicle improve  # suggestions to work more effectively with Copilot",
       "/chronicle search JWT  # search all sessions for mentions of JWT",
-      "/chronicle cost-tips  # get personalized tips to reduce token usage"
+      "/chronicle cost-tips  # get personalized tips to reduce token usage",
+      "/chronicle skills review  # review proposed draft skill changes (accept, reject, or defer)"
     ],
     "category": "agents",
     "terminalDemo": "images/agents/chronicle.gif"

--- a/src/data/categories/code.json
+++ b/src/data/categories/code.json
@@ -55,14 +55,15 @@
   {
     "id": "pr",
     "title": "/pr",
-    "syntax": "/pr [view|create|fix|auto]",
-    "description": "Manage pull requests for the current branch: view existing PRs, create one with an AI-generated description, auto-fix review comments, or use auto mode.",
+    "syntax": "/pr [view|create|fix|auto|automerge]",
+    "description": "Manage pull requests for the current branch: view existing PRs, create one with an AI-generated description, auto-fix review comments, run a self-paced loop to drive the PR to green, or keep looping until the PR is merged.",
     "analogy": "Like a PR dashboard inside your terminal — create, inspect, and respond to review feedback without switching context.",
     "examples": [
       "/pr view  # show the open PR for the current branch",
       "/pr create  # create a PR with an AI-generated description",
       "/pr fix  # let Copilot automatically address review comments",
-      "/pr auto  # create PR and fix review comments automatically"
+      "/pr auto  # self-paced loop: fix one thing per run, pace around CI to reach green",
+      "/pr automerge  # keep looping until the PR passes CI and is merged"
     ],
     "category": "code",
     "terminalDemo": "images/code/pr.gif"
@@ -95,13 +96,13 @@
   {
     "id": "worktree",
     "title": "/worktree",
-    "syntax": "/worktree [BRANCH]",
-    "description": "Create a new git worktree and switch into it, moving any uncommitted changes along. Also available as /move.",
-    "analogy": "Like cloning your workspace into a parallel checkout — work on multiple branches simultaneously without stashing or losing context.",
+    "syntax": "/worktree [TASK]",
+    "description": "Create a new git worktree for parallel development. Pass an optional task description to auto-name the branch and run the task as the first prompt in the new worktree. Without an argument, names the branch from your uncommitted changes and recent conversation.",
+    "analogy": "Like opening a parallel universe of your repo — work on a separate branch simultaneously without disturbing your current session.",
     "examples": [
-      "/worktree  # create a worktree for the current branch",
-      "/worktree feature/auth-fix  # create a named worktree and switch into it",
-      "/move  # alias for /worktree"
+      "/worktree  # create a worktree with a branch named from current changes",
+      "/worktree fix the login redirect  # create branch for this task and start it immediately",
+      "/worktree feature/JIRA-123  # create worktree with an exact branch name"
     ],
     "category": "code",
     "terminalDemo": "images/code/worktree.gif"

--- a/src/data/categories/mcp.json
+++ b/src/data/categories/mcp.json
@@ -2,13 +2,14 @@
   {
     "id": "lsp",
     "title": "/lsp",
-    "syntax": "/lsp [show|test|reload|help] [SERVER-NAME]",
+    "syntax": "/lsp [show|test|reload|logs|help] [SERVER-NAME]",
     "description": "Manage language server (LSP) configurations that give Copilot live diagnostics, type information, and symbol references from your codebase.",
     "analogy": "Like plugging a code-aware lens into Copilot — the LSP feeds it real-time type errors and definitions from your actual project.",
     "examples": [
       "/lsp show  # list all configured language servers",
       "/lsp test typescript  # test the TypeScript language server connection",
-      "/lsp reload  # reload LSP configs after making changes"
+      "/lsp reload  # reload LSP configs after making changes",
+      "/lsp logs  # view LSP server log output for debugging"
     ],
     "category": "mcp",
     "terminalDemo": "images/mcp/lsp.gif"


### PR DESCRIPTION
Replaces PR #26. Updates /worktree description (v1.0.66 behavior), /chronicle with `skills` subcommand, /lsp with `logs` subcommand, /pr with `automerge` subcommand.