### PR TITLE
[bot] Add /refine and /plugins commands, update /mcp with list subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,20 +19,20 @@ Built with React, Vite, and TypeScript. Data-driven — all commands are split i
 
 ## Categories
 
-The 72 commands are organized into 11 categories:
+The 74 commands are organized into 11 categories:
 
 | Category           | Commands | Description                                             |
 | ------------------ | -------- | ------------------------------------------------------- |
 | 🚀 Getting Started | 9        | Install, update, help, version, feedback                |
 | 🔐 Authentication  | 3        | Login, logout, account switching                        |
-| 💬 Chat            | 8        | Ask, clear, search, undo, new, schedule prompts         |
+| 💬 Chat            | 9        | Ask, clear, search, undo, new, refine, schedule prompts |
 | 🧬 Models          | 3        | Model selection, experimental features, themes          |
 | ⚙️ Configuration   | 14       | Directories, permissions, environment, voice, streaming |
 | 💻 Code            | 8        | Diff, plan, PR management, code review, fork, branch    |
 | 🤖 Agents          | 9        | Agent picker, fleet, delegate, research, tasks          |
 | 🔌 MCP             | 2        | MCP and LSP server management                           |
 | 🧠 Memory          | 6        | Sessions, context, compaction, sharing                  |
-| 📝 Instructions    | 3        | Custom instructions, skills, plugins                    |
+| 📝 Instructions    | 4        | Custom instructions, skills, plugins, plugins dashboard |
 | 🔧 Troubleshooting | 7        | Diagnostics, restart, remote control, exit, diagnose    |
 
 ## Tech stack

--- a/scripts/demos.json
+++ b/scripts/demos.json
@@ -227,6 +227,13 @@
       "responseWait": 6
     },
     {
+      "id": "refine",
+      "category": "chat",
+      "description": "Refine a rough prompt into a clear, well-structured one",
+      "command": "/refine so basically i want like a button that does the thing with the files maybe sort them",
+      "responseWait": 20
+    },
+    {
       "id": "after",
       "category": "chat",
       "description": "Schedule a one-off delayed prompt",
@@ -503,6 +510,13 @@
       "category": "instructions",
       "description": "Show loaded instruction files",
       "command": "/instructions",
+      "responseWait": 6
+    },
+    {
+      "id": "plugins",
+      "category": "instructions",
+      "description": "Open the plugins dashboard",
+      "command": "/plugins",
       "responseWait": 6
     },
     {

--- a/src/data/categories/chat.json
+++ b/src/data/categories/chat.json
@@ -93,6 +93,18 @@
     "terminalDemo": "images/chat/every.gif"
   },
   {
+    "id": "refine",
+    "title": "/refine",
+    "syntax": "/refine [PROMPT]",
+    "description": "Rewrite a rough, stream-of-consciousness prompt into a clear, well-structured one before sending it.",
+    "analogy": "Like having an editor polish a draft before it goes out — Copilot cleans up your rambling idea into a precise request.",
+    "examples": [
+      "/refine so basically i want like a button that does the thing with the files maybe sort them",
+      "/refine  # prompts you to type your rough idea interactively"
+    ],
+    "category": "chat"
+  },
+  {
     "id": "after",
     "title": "/after",
     "syntax": "/after <DELAY> [PROMPT]",

--- a/src/data/categories/instructions.json
+++ b/src/data/categories/instructions.json
@@ -12,6 +12,17 @@
     "terminalDemo": "images/instructions/instructions.gif"
   },
   {
+    "id": "plugins",
+    "title": "/plugins",
+    "syntax": "/plugins",
+    "description": "Open the interactive plugins dashboard to browse, enable, disable, and manage installed Copilot CLI plugins.",
+    "analogy": "Like an extension manager in your IDE — one screen to view and control every installed plugin without using subcommands.",
+    "examples": [
+      "/plugins  # open the interactive plugins dashboard"
+    ],
+    "category": "instructions"
+  },
+  {
     "id": "plugin",
     "title": "/plugin",
     "syntax": "/plugin [marketplace|install|uninstall|update|list] [ARGS...]",

--- a/src/data/categories/mcp.json
+++ b/src/data/categories/mcp.json
@@ -17,11 +17,12 @@
   {
     "id": "mcp",
     "title": "/mcp",
-    "syntax": "/mcp [show|add|edit|delete|disable|enable|auth|reload|registry] [SERVER]",
-    "description": "Manage MCP (Model Context Protocol) server configurations — add, remove, enable, disable, reload servers, or browse the MCP registry to install new servers.",
+    "syntax": "/mcp [show|list|add|edit|delete|disable|enable|auth|reload|registry] [SERVER]",
+    "description": "Manage MCP (Model Context Protocol) server configurations — add, remove, enable, disable, reload servers, or browse the MCP registry to install new servers. Use /mcp list to quickly see attached servers and their status.",
     "analogy": "Like a plugin manager in an IDE — /mcp is the control panel for every external tool extension connected to Copilot.",
     "examples": [
       "/mcp show  # list all configured MCP servers and their status",
+      "/mcp list  # show attached MCP servers and connection status",
       "/mcp disable my-server  # temporarily disable a server without removing it",
       "/mcp reload  # reload all MCP server configs without restarting",
       "/mcp auth my-server  # trigger a fresh OAuth flow for a remote server",


### PR DESCRIPTION
> [!CAUTION]
> Protected files were modified in this change.
> This pull request is in `request_review` mode and requires explicit human scrutiny before merge.
>
> Protected files: `README.md`



## What changed

New commands and syntax updates from the Copilot CLI changelog entries for **v1.0.69** (2026-07-07) and **v1.0.70** (2026-07-10).

### Changelog references
- [v1.0.70](https://github.com/github/copilot-cli/releases/tag/v1.0.70): "Add /refine to rewrite a rough, stream-of-consciousness prompt into a clear one"
- [v1.0.69](https://github.com/github/copilot-cli/releases/tag/v1.0.69): "Add a /plugins dashboard to manage installed plugins"
- [v1.0.69](https://github.com/github/copilot-cli/releases/tag/v1.0.69): "Add /mcp list to show attached MCP servers and their status"

### Files updated

**`src/data/categories/chat.json`**
- Added `/refine` — new command to rewrite rough prompts into clear, well-structured ones.

**`src/data/categories/instructions.json`**
- Added `/plugins` — new interactive dashboard to browse, enable, disable, and manage installed plugins (distinct from the existing `/plugin` subcommand-based interface).

**`src/data/categories/mcp.json`**
- Updated `/mcp` syntax to include the `list` subcommand: `[show|list|add|edit|delete|disable|enable|auth|reload|registry]`
- Added `/mcp list` example and description update.

**`scripts/demos.json`**
- Added demo entries for `/refine` and `/plugins`.

**`README.md`**
- Updated total command count: 72 → 74.
- Updated Chat category count: 8 → 9.
- Updated Instructions category count: 3 → 4.

### Pending availability

No commands were excluded — all three changes are confirmed in published stable releases (v1.0.69 and v1.0.70).

> **Note for maintainer**: This PR has the `needs-gifs` label. After merging, run `npm run create:tape -- --id refine` and `npm run create:tape -- --id plugins` to generate tape files, then `npm run create:gif -- --id refine` and `npm run create:gif -- --id plugins` to record demos.




> Generated by [Cheatsheet Updater](https://github.com/prasadhonrao/ghcp-cli-cheatsheet/actions/runs/29233378787) · sonnet46 1.6M · [◷](https://github.com/search?q=repo%3Aprasadhonrao%2Fghcp-cli-cheatsheet+%22gh-aw-workflow-id%3A+cheatsheet-updater%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Cheatsheet Updater, engine: copilot, version: 1.0.52, model: claude-sonnet-4.6, id: 29233378787, workflow_id: cheatsheet-updater, run: https://github.com/prasadhonrao/ghcp-cli-cheatsheet/actions/runs/29233378787 -->

<!-- gh-aw-workflow-id: cheatsheet-updater -->