### PR TITLE
[bot] Add /move command and update /worktree + /voice for v1.0.71

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The 72 commands are organized into 11 categories:
 | 💬 Chat            | 8        | Ask, clear, search, undo, new, schedule prompts         |
 | 🧬 Models          | 3        | Model selection, experimental features, themes          |
 | ⚙️ Configuration   | 14       | Directories, permissions, environment, voice, streaming |
-| 💻 Code            | 8        | Diff, plan, PR management, code review, fork, branch    |
+| 💻 Code            | 9        | Diff, plan, PR management, code review, fork, branch    |
 | 🤖 Agents          | 9        | Agent picker, fleet, delegate, research, tasks          |
 | 🔌 MCP             | 2        | MCP and LSP server management                           |
 | 🧠 Memory          | 6        | Sessions, context, compaction, sharing                  |

--- a/scripts/demos.json
+++ b/scripts/demos.json
@@ -313,8 +313,15 @@
     {
       "id": "worktree",
       "category": "code",
-      "description": "Create a new git worktree and switch into it",
+      "description": "Create a new git worktree, leaving uncommitted changes in the current session",
       "command": "/worktree",
+      "responseWait": 10
+    },
+    {
+      "id": "move",
+      "category": "code",
+      "description": "Create a new git worktree and carry uncommitted changes into it",
+      "command": "/move fix the login redirect",
       "responseWait": 10
     },
     {

--- a/src/data/categories/code.json
+++ b/src/data/categories/code.json
@@ -97,14 +97,27 @@
     "id": "worktree",
     "title": "/worktree",
     "syntax": "/worktree [TASK]",
-    "description": "Create a new git worktree for parallel development. Pass an optional task description to auto-name the branch and run the task as the first prompt in the new worktree. Without an argument, names the branch from your uncommitted changes and recent conversation.",
-    "analogy": "Like opening a parallel universe of your repo — work on a separate branch simultaneously without disturbing your current session.",
+    "description": "Create a new git worktree for parallel development, leaving your uncommitted changes behind in the current session. Pass an optional task description to auto-name the branch and run the task as the first prompt in the new worktree. Use /move instead if you want to carry uncommitted changes into the new worktree.",
+    "analogy": "Like opening a parallel universe of your repo — start a fresh branch simultaneously while keeping your in-progress work exactly where it is.",
     "examples": [
-      "/worktree  # create a worktree with a branch named from current changes",
+      "/worktree  # create a worktree, leaving uncommitted changes in current session",
       "/worktree fix the login redirect  # create branch for this task and start it immediately",
       "/worktree feature/JIRA-123  # create worktree with an exact branch name"
     ],
     "category": "code",
     "terminalDemo": "images/code/worktree.gif"
+  },
+  {
+    "id": "move",
+    "title": "/move",
+    "syntax": "/move [TASK]",
+    "description": "Create a new git worktree and carry your uncommitted changes into it. Unlike /worktree (which leaves changes behind), /move transfers your in-progress work to the new branch so you can continue without stashing.",
+    "analogy": "Like picking up your desk and moving it to a new room — your work comes with you to the new branch.",
+    "examples": [
+      "/move  # create a worktree and bring uncommitted changes along",
+      "/move fix the login redirect  # move changes to a new branch named for the task",
+      "/move feature/JIRA-123  # move changes to a worktree with an exact branch name"
+    ],
+    "category": "code"
   }
 ]

--- a/src/data/categories/configuration.json
+++ b/src/data/categories/configuration.json
@@ -178,12 +178,13 @@
   {
     "id": "voice",
     "title": "/voice",
-    "syntax": "/voice [on|off]",
-    "description": "Enable or disable voice input for the Copilot CLI session. When on, you can speak prompts instead of typing them.",
+    "syntax": "/voice [on|off|devices]",
+    "description": "Enable or disable voice input for the Copilot CLI session, or list and select a microphone with /voice devices. When on, you can speak prompts instead of typing them.",
     "analogy": "Like switching from keyboard to microphone in a voice assistant — talk to Copilot hands-free.",
     "examples": [
       "/voice on  # enable microphone input",
       "/voice off  # switch back to keyboard input",
+      "/voice devices  # list available microphones and choose which one to use",
       "/voice  # check current voice input status"
     ],
     "category": "configuration",


### PR DESCRIPTION
> [!CAUTION]
> Protected files were modified in this change.
> This pull request is in `request_review` mode and requires explicit human scrutiny before merge.
>
> Protected files: `README.md`



## What changed

Based on the [v1.0.71 stable release](https://github.com/github/copilot-cli/releases/tag/v1.0.71) (2026-07-16), this PR updates the cheatsheet with the following confirmed changes:

### New command: `/move` (code category)

v1.0.71 split `/worktree` into two commands. The new `/move` command carries your uncommitted changes into the new worktree, while `/worktree` now leaves them behind.

> "Split /worktree and /move: /worktree now creates a new worktree and leaves your uncommitted changes behind, while the new /move carries them into the new worktree"

### Updated: `/worktree` description

Updated to accurately reflect the new behaviour — it now explicitly leaves uncommitted changes in the current session and points users to `/move` when they want to take their changes with them.

### Updated: `/voice` — added `devices` subcommand

v1.0.71 added `/voice devices` to choose and persist the microphone for voice mode.

> "Add /voice devices to choose and persist the microphone for voice mode"

## Files changed

| File | Change |
|------|--------|
| `src/data/categories/code.json` | Added `/move` entry; updated `/worktree` description |
| `src/data/categories/configuration.json` | Updated `/voice` syntax to `[on\|off\|devices]` + added `devices` example |
| `scripts/demos.json` | Added demo entry for `/move`; updated `/worktree` demo description |
| `README.md` | Updated Code category command count: 8 → 9 |

## Pending availability

No commands are pending. All changes in this PR are from the v1.0.71 **stable** release (not a pre-release).

The v1.0.72-0 and v1.0.72-1 pre-releases contain additional improvements (multi-turn subagents always enabled, `--plugin`/`--mcp`/`--skill` flags for plugin mutations) but these are not stable releases yet and are excluded from this PR.




> Generated by [Cheatsheet Updater](https://github.com/prasadhonrao/ghcp-cli-cheatsheet/actions/runs/29725502505) · sonnet46 1.3M · [◷](https://github.com/search?q=repo%3Aprasadhonrao%2Fghcp-cli-cheatsheet+%22gh-aw-workflow-id%3A+cheatsheet-updater%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Cheatsheet Updater, engine: copilot, version: 1.0.52, model: claude-sonnet-4.6, id: 29725502505, workflow_id: cheatsheet-updater, run: https://github.com/prasadhonrao/ghcp-cli-cheatsheet/actions/runs/29725502505 -->

<!-- gh-aw-workflow-id: cheatsheet-updater -->