### PR TITLE
[bot] Update /model with plan mode option and /plugin with new verbs (v1.0.72–v1.0.74)

### DIFF
--- a/src/data/categories/instructions.json
+++ b/src/data/categories/instructions.json
@@ -14,14 +14,18 @@
   {
     "id": "plugin",
     "title": "/plugin",
-    "syntax": "/plugin [marketplace|install|uninstall|update|list] [ARGS...]",
-    "description": "Manage Copilot CLI plugins — packages that bundle agents, skills, and MCP servers in a single install.",
+    "syntax": "/plugin [marketplace|install|uninstall|update|list|enable|disable|remove|help] [--plugin|--mcp|--skill] [ARGS...]",
+    "description": "Manage Copilot CLI plugins — packages that bundle agents, skills, and MCP servers in a single install. Also available as /plugins. Use `enable`/`disable`/`remove` with `--plugin`, `--mcp`, or `--skill` flags (or a positional kind) to target specific resource types. Install skills directly with `install --skill`.",
     "analogy": "Like an extension marketplace for your IDE — browse, install, and manage add-ons that extend what Copilot can do.",
     "examples": [
       "/plugin list  # show all installed plugins",
       "/plugin marketplace  # browse available plugins",
       "/plugin install my-org/my-plugin  # install a plugin",
-      "/plugin update  # update all installed plugins"
+      "/plugin update  # update all installed plugins",
+      "/plugin enable --skill my-skill  # enable a specific skill",
+      "/plugin disable --mcp my-server  # disable an MCP server",
+      "/plugin install --skill my-org/my-skill  # install a skill directly",
+      "/plugin help  # show all plugin subcommands"
     ],
     "category": "instructions",
     "terminalDemo": "images/instructions/plugin.gif"

--- a/src/data/categories/models.json
+++ b/src/data/categories/models.json
@@ -16,13 +16,16 @@
   {
     "id": "model",
     "title": "/model",
-    "syntax": "/model [MODEL]",
-    "description": "Select or switch the AI model mid-session. Run without arguments for an interactive picker. Also available as /models.",
+    "syntax": "/model [MODEL | plan [MODEL|off]]",
+    "description": "Select or switch the AI model mid-session. Run without arguments for an interactive picker. Use `/model plan` (or `/model --plan`) to set a separate model for plan mode — pass a model id, `off` to clear, or no id to open the picker. The plan-mode model reverts to the session model when you leave plan mode. Also available as /models.",
     "analogy": "Like switching between AI tiers in a chat app — pick the right power level for the task at hand.",
     "examples": [
       "/model  # open interactive model picker",
       "/models  # alias for /model",
-      "/model claude-sonnet-4-5  # switch to a specific model by name"
+      "/model claude-sonnet-4-5  # switch to a specific model by name",
+      "/model plan  # open picker to set a model specifically for plan mode",
+      "/model plan claude-opus-4-5  # use claude-opus-4-5 while in plan mode",
+      "/model plan off  # clear the plan-mode model override"
     ],
     "category": "models",
     "terminalDemo": "images/models/model.gif"


### PR DESCRIPTION
## Summary

Two command updates found in changelog entries from the past 7 days (2026-07-20 to 2026-07-24).

---

### Changes found in changelog

**v1.0.74 (2026-07-23)** — [release](https://github.com/github/copilot-cli/releases/tag/v1.0.74)
> Add `/model plan` (or `/model --plan`) to pick a model used while in plan mode; pass a model id, `off` to clear, or no id to open the picker. Reverts to the session model when you leave plan mode.

**v1.0.75 (2026-07-24)** — [release](https://github.com/github/copilot-cli/releases/tag/v1.0.75)
> Add support for Claude Opus 5

(Claude Opus 5 is a model addition — no command-level changes required.)

**v1.0.72 (2026-07-20)** — [release](https://github.com/github/copilot-cli/releases/tag/v1.0.74)
> Add `update`/`uninstall` verbs to `/plugins`, let `enable`/`disable`/`remove` target plugins, MCP servers, or skills via `--plugin`/`--mcp`/`--skill` flags or a positional kind, and support installing skills with `/plugins install --skill`
> Add a `/plugins help` command plus skill, MCP, and marketplace management for full `/plugin` parity

---

### Files updated

**`src/data/categories/models.json`** — `/model` entry
- Updated `syntax` from `/model [MODEL]` to `/model [MODEL | plan [MODEL|off]]`
- Updated `description` to explain the new plan mode override behaviour
- Added 3 new examples: `/model plan`, `/model plan claude-opus-4-5`, `/model plan off`

**`src/data/categories/instructions.json`** — `/plugin` entry
- Updated `syntax` to include `enable`, `disable`, `remove`, `help` verbs and `--plugin`/`--mcp`/`--skill` flags
- Updated `description` to explain targeting by resource type and skill install
- Added 4 new examples covering the new verbs and flag combinations
- Documented `/plugins` as alias

---

### Commands verified as available

| Command | Version | Status |
|---------|---------|--------|
| `/model plan` | v1.0.74 (published 2026-07-23) | ✅ Available |
| `/plugin enable/disable/remove` + flags | v1.0.72 (published 2026-07-20) | ✅ Available |

---

### Pending availability

None — all changelog changes from the past 7 days are either already in a published release or are model additions (not command changes).

---

> **Note for maintainer**: No new commands were added, so no GIF recordings are required for this PR. Existing `terminalDemo` references in both files are unchanged.




> Generated by [Cheatsheet Updater](https://github.com/prasadhonrao/ghcp-cli-cheatsheet/actions/runs/30248451386) · sonnet46 1.6M · [◷](https://github.com/search?q=repo%3Aprasadhonrao%2Fghcp-cli-cheatsheet+%22gh-aw-workflow-id%3A+cheatsheet-updater%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Cheatsheet Updater, engine: copilot, version: 1.0.52, model: claude-sonnet-4.6, id: 30248451386, workflow_id: cheatsheet-updater, run: https://github.com/prasadhonrao/ghcp-cli-cheatsheet/actions/runs/30248451386 -->

<!-- gh-aw-workflow-id: cheatsheet-updater -->