### PR TITLE
[bot] Add /limits command, update /login flags and /plugin enable/disable (v1.0.76–1.0.77)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The 72 commands are organized into 11 categories:
 
 | Category           | Commands | Description                                             |
 | ------------------ | -------- | ------------------------------------------------------- |
-| 🚀 Getting Started | 9        | Install, update, help, version, feedback                |
+| 🚀 Getting Started | 10       | Install, update, help, version, feedback, limits        |
 | 🔐 Authentication  | 3        | Login, logout, account switching                        |
 | 💬 Chat            | 8        | Ask, clear, search, undo, new, schedule prompts         |
 | 🧬 Models          | 3        | Model selection, experimental features, themes          |

--- a/scripts/demos.json
+++ b/scripts/demos.json
@@ -485,6 +485,13 @@
       "responseWait": 10
     },
     {
+      "id": "limits",
+      "category": "getting-started",
+      "description": "Show AI-credit limits and predict session usage",
+      "command": "/limits predict",
+      "responseWait": 10
+    },
+    {
       "id": "usage",
       "category": "getting-started",
       "description": "Show session usage metrics",

--- a/src/data/categories/authentication.json
+++ b/src/data/categories/authentication.json
@@ -2,11 +2,13 @@
   {
     "id": "login",
     "title": "/login",
-    "syntax": "/login",
-    "description": "Authenticate with GitHub Copilot from within an active session.",
+    "syntax": "/login [--web-flow | --device-code]",
+    "description": "Authenticate with GitHub Copilot from within an active session. Defaults to browser-based OAuth on local interactive terminals; use flags to force a specific flow.",
     "analogy": "Like showing your badge at the office entrance — without it nothing works, but you only do it once.",
     "examples": [
-      "/login  # start OAuth flow inside the session"
+      "/login  # start OAuth flow (browser by default on local terminals)",
+      "/login --web-flow  # force browser-based OAuth login",
+      "/login --device-code  # force device-code flow (for headless or remote terminals)"
     ],
     "category": "authentication",
     "terminalDemo": "images/authentication/login.gif"

--- a/src/data/categories/getting-started.json
+++ b/src/data/categories/getting-started.json
@@ -91,6 +91,18 @@
     "terminalDemo": "images/getting-started/update.gif"
   },
   {
+    "id": "limits",
+    "title": "/limits",
+    "syntax": "/limits [predict]",
+    "description": "Show your AI-credit limits and usage. Use \"predict\" to get a suggested session limit based on similar past sessions.",
+    "analogy": "Like checking your bank balance before a big purchase — see how much AI quota you have and plan accordingly.",
+    "examples": [
+      "/limits  # show current AI-credit limits",
+      "/limits predict  # suggest a session limit from similar sessions"
+    ],
+    "category": "getting-started"
+  },
+  {
     "id": "usage",
     "title": "/usage",
     "syntax": "/usage",

--- a/src/data/categories/instructions.json
+++ b/src/data/categories/instructions.json
@@ -14,14 +14,16 @@
   {
     "id": "plugin",
     "title": "/plugin",
-    "syntax": "/plugin [marketplace|install|uninstall|update|list] [ARGS...]",
-    "description": "Manage Copilot CLI plugins — packages that bundle agents, skills, and MCP servers in a single install.",
-    "analogy": "Like an extension marketplace for your IDE — browse, install, and manage add-ons that extend what Copilot can do.",
+    "syntax": "/plugin [marketplace|install|uninstall|update|list|enable|disable] [ARGS...]",
+    "description": "Manage Copilot CLI plugins — packages that bundle agents, skills, and MCP servers in a single install. Enable or disable individual plugins, MCP servers, and skills without removing them.",
+    "analogy": "Like an extension marketplace for your IDE — browse, install, manage, and toggle add-ons that extend what Copilot can do.",
     "examples": [
       "/plugin list  # show all installed plugins",
       "/plugin marketplace  # browse available plugins",
       "/plugin install my-org/my-plugin  # install a plugin",
-      "/plugin update  # update all installed plugins"
+      "/plugin update  # update all installed plugins",
+      "/plugin enable my-plugin  # re-enable a disabled plugin",
+      "/plugin disable my-plugin  # disable a plugin without uninstalling it"
     ],
     "category": "instructions",
     "terminalDemo": "images/instructions/plugin.gif"


### PR DESCRIPTION
> [!CAUTION]
> Protected files were modified in this change.
> This pull request is in `request_review` mode and requires explicit human scrutiny before merge.
>
> Protected files: `README.md`



## What changed

Updates the cheatsheet to reflect new features in Copilot CLI **v1.0.76** (2026-07-29) and **v1.0.77** (2026-07-30).

---

### New command: `/limits` — added in v1.0.76

**File:** `src/data/categories/getting-started.json`

Added a new `/limits [predict]` entry. The `predict` subcommand suggests a session AI-credit limit based on similar past sessions. Also added a demo entry to `scripts/demos.json`.

Changelog reference: _"Add /limits predict to suggest a session AI-credit limit from similar sessions."_ (v1.0.76)

---

### Updated: `/login` — new flags in v1.0.77

**File:** `src/data/categories/authentication.json`

The browser-based (web) OAuth flow is now the **default** for `copilot login` on local interactive terminals. Device code remains the default on remote/headless terminals. Added `--web-flow` and `--device-code` flags to the syntax and examples.

Changelog reference: _"Add a browser-based (web) OAuth login flow, now the default for `copilot login` on local interactive terminals... Use `--web-flow`/`--device-code` to force a mode, or pick one in the interactive `/login` command"_ (v1.0.77)

---

### Updated: `/plugin` — enable/disable subcommands in v1.0.76

**File:** `src/data/categories/instructions.json`

Added `enable` and `disable` to the `/plugin` command syntax and examples. These new subcommands allow toggling plugins (and MCP servers/skills via flags) without uninstalling them.

Changelog reference: _"Add enable/disable controls in /plugins for plugins, instructions, agents, LSP servers, and hooks"_ (v1.0.76)

---

### README

Updated the Getting Started command count from 9 → 10 to reflect the new `/limits` entry.

---

## Pending availability

None — all three changes are confirmed present in the latest published release **v1.0.77** (2026-07-30).

---

## Notes for maintainer

The new `/limits` entry does not have a `terminalDemo` field yet. Please generate a GIF after merge:

```bash
npm run create:tape -- --id limits
npm run create:gif -- --id limits
```

Then add `"terminalDemo": "images/getting-started/limits.gif"` to the entry in `src/data/categories/getting-started.json`.




> Generated by [Cheatsheet Updater](https://github.com/prasadhonrao/ghcp-cli-cheatsheet/actions/runs/30795657199) · sonnet46 2.4M · [◷](https://github.com/search?q=repo%3Aprasadhonrao%2Fghcp-cli-cheatsheet+%22gh-aw-workflow-id%3A+cheatsheet-updater%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Cheatsheet Updater, engine: copilot, version: 1.0.52, model: claude-sonnet-4.6, id: 30795657199, workflow_id: cheatsheet-updater, run: https://github.com/prasadhonrao/ghcp-cli-cheatsheet/actions/runs/30795657199 -->

<!-- gh-aw-workflow-id: cheatsheet-updater -->