### PR TITLE
[bot] Add /permissions and /new-worktree commands (v1.0.78)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ The 72 commands are organized into 11 categories:
 | 🔐 Authentication  | 3        | Login, logout, account switching                        |
 | 💬 Chat            | 8        | Ask, clear, search, undo, new, schedule prompts         |
 | 🧬 Models          | 3        | Model selection, experimental features, themes          |
-| ⚙️ Configuration   | 14       | Directories, permissions, environment, voice, streaming |
-| 💻 Code            | 8        | Diff, plan, PR management, code review, fork, branch    |
+| ⚙️ Configuration   | 15       | Directories, permissions, environment, voice, streaming |
+| 💻 Code            | 9        | Diff, plan, PR management, code review, fork, branch    |
 | 🤖 Agents          | 9        | Agent picker, fleet, delegate, research, tasks          |
 | 🔌 MCP             | 2        | MCP and LSP server management                           |
 | 🧠 Memory          | 6        | Sessions, context, compaction, sharing                  |

--- a/scripts/demos.json
+++ b/scripts/demos.json
@@ -304,6 +304,13 @@
       "responseWait": 10
     },
     {
+      "id": "new-worktree",
+      "category": "code",
+      "description": "Create a new worktree and start a fresh session in it",
+      "command": "/new-worktree add dark-mode support",
+      "responseWait": 10
+    },
+    {
       "id": "review",
       "category": "code",
       "description": "Run code review agent",
@@ -394,6 +401,13 @@
       "category": "configuration",
       "description": "Reset all tool permissions",
       "command": "/reset-allowed-tools",
+      "responseWait": 6
+    },
+    {
+      "id": "permissions",
+      "category": "configuration",
+      "description": "Open the approval-mode picker",
+      "command": "/permissions",
       "responseWait": 6
     },
     {

--- a/src/data/categories/code.json
+++ b/src/data/categories/code.json
@@ -94,6 +94,19 @@
     "category": "code"
   },
   {
+    "id": "new-worktree",
+    "title": "/new-worktree",
+    "syntax": "/new-worktree [TASK]",
+    "description": "Create a new git worktree and immediately start a fresh Copilot conversation in it, leaving your current session and uncommitted changes behind. Only available in experimental mode.",
+    "analogy": "Like opening a brand-new branch in a separate window — start a parallel task with a clean slate while your current work stays untouched.",
+    "examples": [
+      "/new-worktree  # create a new worktree and open a fresh session in it",
+      "/new-worktree add dark-mode support  # create worktree and start this task immediately"
+    ],
+    "note": "Requires /experimental mode. See also: /worktree — carries uncommitted changes into the new worktree instead of leaving them behind.",
+    "category": "code"
+  },
+  {
     "id": "worktree",
     "title": "/worktree",
     "syntax": "/worktree [TASK]",

--- a/src/data/categories/configuration.json
+++ b/src/data/categories/configuration.json
@@ -113,6 +113,17 @@
     "terminalDemo": "images/configuration/loop.gif"
   },
   {
+    "id": "permissions",
+    "title": "/permissions",
+    "syntax": "/permissions",
+    "description": "Open an interactive dialog to switch between approval modes — controlling how Copilot prompts for tool and command approvals.",
+    "analogy": "Like the permissions settings panel in your OS — choose how strictly Copilot asks before running commands or touching files.",
+    "examples": [
+      "/permissions  # open the approval-mode picker"
+    ],
+    "category": "configuration"
+  },
+  {
     "id": "reset-allowed-tools",
     "title": "/reset-allowed-tools",
     "syntax": "/reset-allowed-tools",


### PR DESCRIPTION
> [!CAUTION]
> Protected files were modified in this change.
> This pull request is in `request_review` mode and requires explicit human scrutiny before merge.
>
> Protected files: `README.md`



## What changed

Two new commands were shipped in **[v1.0.78](https://github.com/github/copilot-cli/releases/tag/v1.0.78)** (2026-08-03) and are now added to the cheatsheet.

### New commands

| Command | Category | Source |
|---|---|---|
| `/permissions` | Configuration | v1.0.78 changelog: _"Add /permissions to switch between approval modes."_ |
| `/new-worktree` | Code | v1.0.78 changelog: _"Add the experimental /new-worktree command to create a new worktree and start a new conversation in it"_ |

### Files updated

- **`src/data/categories/configuration.json`** — Added `/permissions` entry (configuration count: 14 → 15)
- **`src/data/categories/code.json`** — Added `/new-worktree` entry (code count: 8 → 9)
- **`scripts/demos.json`** — Added demo entries for both new commands
- **`README.md`** — Updated command counts for configuration and code categories

### Details

**`/permissions`** opens an interactive dialog to switch between Copilot's approval modes, controlling how it prompts before running tools or touching files. Confirmed available in the published v1.0.78 release.

**`/new-worktree`** creates a new git worktree and opens a fresh Copilot conversation in it, leaving uncommitted changes in the current session. Requires `/experimental` mode. Confirmed available in the published v1.0.78 release.

## Pending availability

None — both commands are confirmed in the published v1.0.78 release (2026-08-03).

> **Note for maintainer:** GIFs for the two new commands need to be recorded locally after merge using:
> ```bash
> npm run create:tape -- --id permissions
> npm run create:gif -- --id permissions
> npm run create:tape -- --id new-worktree
> npm run create:gif -- --id new-worktree
> ```




> Generated by [Cheatsheet Updater](https://github.com/prasadhonrao/ghcp-cli-cheatsheet/actions/runs/31360304354) · sonnet46 2M · [◷](https://github.com/search?q=repo%3Aprasadhonrao%2Fghcp-cli-cheatsheet+%22gh-aw-workflow-id%3A+cheatsheet-updater%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Cheatsheet Updater, engine: copilot, version: 1.0.52, model: claude-sonnet-4.6, id: 31360304354, workflow_id: cheatsheet-updater, run: https://github.com/prasadhonrao/ghcp-cli-cheatsheet/actions/runs/31360304354 -->

<!-- gh-aw-workflow-id: cheatsheet-updater -->