### PR TITLE
[bot] Add /sandbox, update /worktree new, /app, and /model for v1.0.79–v1.0.80

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Built with React, Vite, and TypeScript. Data-driven — all commands are split i
 
 ## Categories
 
-The 72 commands are organized into 11 categories:
+The 73 commands are organized into 11 categories:
 
 | Category           | Commands | Description                                             |
 | ------------------ | -------- | ------------------------------------------------------- |
@@ -27,7 +27,7 @@ The 72 commands are organized into 11 categories:
 | 🔐 Authentication  | 3        | Login, logout, account switching                        |
 | 💬 Chat            | 8        | Ask, clear, search, undo, new, schedule prompts         |
 | 🧬 Models          | 3        | Model selection, experimental features, themes          |
-| ⚙️ Configuration   | 14       | Directories, permissions, environment, voice, streaming |
+| ⚙️ Configuration   | 15       | Directories, permissions, environment, voice, streaming |
 | 💻 Code            | 8        | Diff, plan, PR management, code review, fork, branch    |
 | 🤖 Agents          | 9        | Agent picker, fleet, delegate, research, tasks          |
 | 🔌 MCP             | 2        | MCP and LSP server management                           |

--- a/scripts/demos.json
+++ b/scripts/demos.json
@@ -425,6 +425,13 @@
       "responseWait": 6
     },
     {
+      "id": "sandbox",
+      "category": "configuration",
+      "description": "View sandbox configuration and effective policy",
+      "command": "/sandbox policy",
+      "responseWait": 6
+    },
+    {
       "id": "voice",
       "category": "configuration",
       "description": "Enable voice input",

--- a/src/data/categories/code.json
+++ b/src/data/categories/code.json
@@ -96,11 +96,12 @@
   {
     "id": "worktree",
     "title": "/worktree",
-    "syntax": "/worktree [TASK]",
-    "description": "Create a new git worktree for parallel development. Pass an optional task description to auto-name the branch and run the task as the first prompt in the new worktree. Without an argument, names the branch from your uncommitted changes and recent conversation.",
+    "syntax": "/worktree [new|TASK]",
+    "description": "Create a new git worktree for parallel development. Use 'new' to start a fresh session in a new worktree. Pass a task description to auto-name the branch and run the task as the first prompt. Without an argument, names the branch from your uncommitted changes and recent conversation.",
     "analogy": "Like opening a parallel universe of your repo — work on a separate branch simultaneously without disturbing your current session.",
     "examples": [
       "/worktree  # create a worktree with a branch named from current changes",
+      "/worktree new  # start a new session in a fresh worktree",
       "/worktree fix the login redirect  # create branch for this task and start it immediately",
       "/worktree feature/JIRA-123  # create worktree with an exact branch name"
     ],

--- a/src/data/categories/configuration.json
+++ b/src/data/categories/configuration.json
@@ -176,6 +176,18 @@
     "terminalDemo": "images/configuration/terminal-setup.gif"
   },
   {
+    "id": "sandbox",
+    "title": "/sandbox",
+    "syntax": "/sandbox [policy]",
+    "description": "View and configure the sandbox that isolates Copilot's file and network access. Use 'policy' to display the effective paths, denials, and network access rules for the current session.",
+    "analogy": "Like viewing your firewall rules — see exactly which files and network destinations Copilot is allowed to reach, and why some settings are locked.",
+    "examples": [
+      "/sandbox  # open the sandbox configuration dialog",
+      "/sandbox policy  # show effective sandbox paths, denials, and network access rules"
+    ],
+    "category": "configuration"
+  },
+  {
     "id": "voice",
     "title": "/voice",
     "syntax": "/voice [on|off]",

--- a/src/data/categories/getting-started.json
+++ b/src/data/categories/getting-started.json
@@ -3,10 +3,10 @@
     "id": "app",
     "title": "/app",
     "syntax": "/app",
-    "description": "Open the GitHub app or a browser fallback directly from the CLI.",
-    "analogy": "Like a home button for GitHub — jump straight to the GitHub interface without leaving the terminal.",
+    "description": "Open the current session in the GitHub Copilot desktop app, or fall back to a browser if the app is not installed. Requires GitHub Copilot app 1.1.3 or later.",
+    "analogy": "Like a 'Open in app' button — jump from the terminal directly into the desktop app with your current session intact.",
     "examples": [
-      "/app  # open the GitHub app or launch a browser if the app is not installed"
+      "/app  # open the current session in the GitHub Copilot app (requires app 1.1.3+)"
     ],
     "category": "getting-started",
     "terminalDemo": "images/getting-started/app.gif"

--- a/src/data/categories/models.json
+++ b/src/data/categories/models.json
@@ -17,13 +17,14 @@
     "id": "model",
     "title": "/model",
     "syntax": "/model [MODEL]",
-    "description": "Select or switch the AI model mid-session. Run without arguments for an interactive picker. Also available as /models.",
+    "description": "Select or switch the AI model for the current session. Run without arguments for an interactive picker. Changes apply to the current session only — use /config model to set a default for future sessions. Also available as /models.",
     "analogy": "Like switching between AI tiers in a chat app — pick the right power level for the task at hand.",
     "examples": [
       "/model  # open interactive model picker",
       "/models  # alias for /model",
       "/model claude-sonnet-4-5  # switch to a specific model by name"
     ],
+    "note": "/model is session-scoped. To set a persistent default, use /config model.",
     "category": "models",
     "terminalDemo": "images/models/model.gif"
   },


### PR DESCRIPTION
> [!CAUTION]
> Protected files were modified in this change.
> This pull request is in `request_review` mode and requires explicit human scrutiny before merge.
>
> Protected files: `README.md`



## What changed

Based on GitHub Copilot CLI releases **v1.0.79** (2026-08-10) and **v1.0.80** (2026-08-14).

### New commands

- **`/sandbox`** (configuration category) — Added missing command. Provides a configuration dialog for the sandbox that isolates Copilot's file and network access. The new `/sandbox policy` subcommand (added in v1.0.79) shows the effective sandbox paths, denials, and network access rules.

### Updated commands

- **`/worktree`** (`src/data/categories/code.json`) — Added `/worktree new` subcommand. Per v1.0.79: _"Use /worktree new to start a new session in a new worktree."_ Updated syntax to `/worktree [new|TASK]` and added example.

- **`/app`** (`src/data/categories/getting-started.json`) — Updated description and example. Per v1.0.79: _"The /app command now opens the current session in the GitHub Copilot desktop app instead of landing on Home with the wrong folder (requires GitHub Copilot app 1.1.3 or later)."_

- **`/model`** (`src/data/categories/models.json`) — Updated description and added note. Per v1.0.79: _"Make /model session-scoped by default, and use /config model to set defaults for future sessions."_

### Other changes

- Added `/sandbox` demo entry to `scripts/demos.json`
- Updated README command count: **72 → 73**
- Updated README Configuration category count: **14 → 15**

### Changelog references

- [v1.0.79 release](https://github.com/github/copilot-cli/releases/tag/v1.0.79) (2026-08-10)
- [v1.0.80 release](https://github.com/github/copilot-cli/releases/tag/v1.0.80) (2026-08-14) — model configuration update only, no new commands

---

## Pending availability

The following changelog entries from the past 7 days were **excluded** because they appear only in prerelease builds (v1.0.80-0, v1.0.81-0) and have not yet shipped in a stable release:

- **`/ahp` command family** (`/ahp start`, `/ahp stop`, `/ahp restart`, `/ahp sessions`, `/ahp attach`, `/ahp new`, `/ahp connect`, `/ahp hosts`, `/ahp use`, `/ahp status`, `/ahp codespace`, `/ahp cloud`) — Agent Host Protocol commands; prerelease only, gated on `AHP_CLIENT` feature flag
- **`--enable-mcp-server` flag** — re-enable MCP servers disabled in settings for current run; prerelease only
- **`/plugin marketplace update [name]`** — refresh marketplace catalogs; prerelease only
- **`/autopilot` without experimental mode** — explicitly set objectives without experimental mode; prerelease only (v1.0.80-0)
- **`--usage-output-file` flag** — write final usage metrics to a JSON file; prerelease only




> Generated by [Cheatsheet Updater](https://github.com/prasadhonrao/ghcp-cli-cheatsheet/actions/runs/31997410107) · sonnet46 2.8M · [◷](https://github.com/search?q=repo%3Aprasadhonrao%2Fghcp-cli-cheatsheet+%22gh-aw-workflow-id%3A+cheatsheet-updater%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Cheatsheet Updater, engine: copilot, version: 1.0.52, model: claude-sonnet-4.6, id: 31997410107, workflow_id: cheatsheet-updater, run: https://github.com/prasadhonrao/ghcp-cli-cheatsheet/actions/runs/31997410107 -->

<!-- gh-aw-workflow-id: cheatsheet-updater -->