### PR TITLE
[bot] Add /sandbox and /config commands, update /worktree with new subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The 72 commands are organized into 11 categories:
 | 🔐 Authentication  | 3        | Login, logout, account switching                        |
 | 💬 Chat            | 8        | Ask, clear, search, undo, new, schedule prompts         |
 | 🧬 Models          | 3        | Model selection, experimental features, themes          |
-| ⚙️ Configuration   | 14       | Directories, permissions, environment, voice, streaming |
+| ⚙️ Configuration   | 16       | Directories, permissions, environment, voice, streaming |
 | 💻 Code            | 8        | Diff, plan, PR management, code review, fork, branch    |
 | 🤖 Agents          | 9        | Agent picker, fleet, delegate, research, tasks          |
 | 🔌 MCP             | 2        | MCP and LSP server management                           |

--- a/scripts/demos.json
+++ b/scripts/demos.json
@@ -404,6 +404,20 @@
       "responseWait": 6
     },
     {
+      "id": "config",
+      "category": "configuration",
+      "description": "View or change persistent CLI defaults, e.g. default model",
+      "command": "/config model",
+      "responseWait": 6
+    },
+    {
+      "id": "sandbox",
+      "category": "configuration",
+      "description": "Open sandbox configuration dialog",
+      "command": "/sandbox",
+      "responseWait": 6
+    },
+    {
       "id": "statusline",
       "category": "configuration",
       "description": "Configure status line items",

--- a/src/data/categories/code.json
+++ b/src/data/categories/code.json
@@ -96,11 +96,12 @@
   {
     "id": "worktree",
     "title": "/worktree",
-    "syntax": "/worktree [TASK]",
-    "description": "Create a new git worktree for parallel development. Pass an optional task description to auto-name the branch and run the task as the first prompt in the new worktree. Without an argument, names the branch from your uncommitted changes and recent conversation.",
+    "syntax": "/worktree [new|TASK]",
+    "description": "Create a new git worktree for parallel development. Pass an optional task description to auto-name the branch and run the task as the first prompt in the new worktree. Use `new` to start a fresh session in a new worktree without a task prompt. Without an argument, names the branch from your uncommitted changes and recent conversation.",
     "analogy": "Like opening a parallel universe of your repo — work on a separate branch simultaneously without disturbing your current session.",
     "examples": [
       "/worktree  # create a worktree with a branch named from current changes",
+      "/worktree new  # start a new session in a new worktree",
       "/worktree fix the login redirect  # create branch for this task and start it immediately",
       "/worktree feature/JIRA-123  # create worktree with an exact branch name"
     ],

--- a/src/data/categories/configuration.json
+++ b/src/data/categories/configuration.json
@@ -150,6 +150,30 @@
     "terminalDemo": "images/configuration/statusline.gif"
   },
   {
+    "id": "config",
+    "title": "/config",
+    "syntax": "/config [model] [VALUE]",
+    "description": "Manage persistent CLI configuration defaults. Use `/config model` to set the default AI model for all future sessions, independent of the session-scoped `/model` selection.",
+    "analogy": "Like the default app settings on your phone — changes here stick across every new session, unlike in-session overrides.",
+    "examples": [
+      "/config model  # view or change the default model for future sessions",
+      "/model  # override the model for just the current session"
+    ],
+    "category": "configuration"
+  },
+  {
+    "id": "sandbox",
+    "title": "/sandbox",
+    "syntax": "/sandbox [policy]",
+    "description": "Open the sandbox configuration dialog to manage shell command restrictions. Use the `policy` subcommand to view effective sandbox paths, network access rules, and denied operations.",
+    "analogy": "Like an app's privacy settings screen — see exactly what the sandbox allows or blocks, and adjust the restrictions.",
+    "examples": [
+      "/sandbox  # open the interactive sandbox configuration dialog",
+      "/sandbox policy  # show effective sandbox paths, network access, and denials"
+    ],
+    "category": "configuration"
+  },
+  {
     "id": "streamer-mode",
     "title": "/streamer-mode",
     "syntax": "/streamer-mode [on|off]",


### PR DESCRIPTION
> [!CAUTION]
> Protected files were modified in this change.
> This pull request is in `request_review` mode and requires explicit human scrutiny before merge.
>
> Protected files: `README.md`



## What changed

Checked the GitHub Copilot CLI changelog and recent releases for new commands not yet documented in the cheatsheet.

### New commands found in v1.0.79 (stable, released 2026-08-10)

**Release notes references:**
- https://github.com/github/copilot-cli/releases/tag/v1.0.79

---

### Files updated

#### `src/data/categories/configuration.json` — 2 new entries

**`/config`** (new command)
> "Make /model session-scoped by default, and use /config model to set defaults for future sessions."

Documents `/config model` for setting persistent default model across sessions — distinct from the session-scoped `/model` picker.

**`/sandbox`** (new command)
> "Add /sandbox policy to show effective sandbox paths, denials, and network access"

Documents the sandbox configuration dialog and its `policy` subcommand for inspecting effective sandbox restrictions.

#### `src/data/categories/code.json` — updated `/worktree`
> "Use /worktree new to start a new session in a new worktree"

Added `new` subcommand to the `/worktree` entry syntax and examples.

#### `scripts/demos.json`
Added demo stubs for `config` and `sandbox` (category: configuration, responseWait: 6).

#### `README.md`
Updated Configuration command count from 14 → 16.

---

### Pending availability

The following changes from pre-releases (v1.0.81-x, published 2026-08-17–2026-08-23) were found but excluded because they are not yet in a stable release:

| Feature | Release | Status |
|---------|---------|--------|
| `copilot app` subcommand (open Copilot desktop app in current directory) | v1.0.81-7 | ⏳ Pre-release only |
| `--with-token` flag for `copilot login` | v1.0.81-6 | ⏳ Pre-release only |
| `defaultMode` / `defaultPermissionMode` settings | v1.0.81-6 | ⏳ Pre-release only |
| `/ahp` session-sharing commands | v1.0.80-0 | ⏳ Pre-release only; also gated behind `AHP_CLIENT` feature flag |




> Generated by [Cheatsheet Updater](https://github.com/prasadhonrao/ghcp-cli-cheatsheet/actions/runs/32693273533) · sonnet46 3M · [◷](https://github.com/search?q=repo%3Aprasadhonrao%2Fghcp-cli-cheatsheet+%22gh-aw-workflow-id%3A+cheatsheet-updater%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Cheatsheet Updater, engine: copilot, version: 1.0.52, model: claude-sonnet-4.6, id: 32693273533, workflow_id: cheatsheet-updater, run: https://github.com/prasadhonrao/ghcp-cli-cheatsheet/actions/runs/32693273533 -->

<!-- gh-aw-workflow-id: cheatsheet-updater -->